### PR TITLE
fix: resolve 9 pre-existing test failures (#25)

### DIFF
--- a/lib/eve_dmv/contexts/corporation/services/stats_loader.ex
+++ b/lib/eve_dmv/contexts/corporation/services/stats_loader.ex
@@ -73,6 +73,12 @@ defmodule EveDmv.Contexts.Corporation.Services.StatsLoader do
     """
 
     case Repo.query(stats_query, [corporation_id, since_date]) do
+      {:ok, %{rows: [[nil, nil, _, _, _]]}} ->
+        # Matview has no rows for this corp (it filters out members with <5
+        # killmails and refreshes on a schedule, so recently-inserted data
+        # also won't appear). Fall back to the direct query.
+        compute_stats_direct(corporation_id, since_date)
+
       {:ok, %{rows: [[kills, losses, isk_destroyed, isk_lost, active_members]]}} ->
         format_stats(kills, losses, isk_destroyed, isk_lost, active_members)
 

--- a/lib/eve_dmv/contexts/system_analysis/domain/regional_correlation_analyzer.ex
+++ b/lib/eve_dmv/contexts/system_analysis/domain/regional_correlation_analyzer.ex
@@ -174,8 +174,12 @@ defmodule EveDmv.Contexts.SystemAnalysis.Domain.RegionalCorrelationAnalyzer do
     clusters =
       systems
       |> Enum.reduce([], fn system, acc ->
+        # The correlation matrix only contains entries for systems with
+        # killmail activity in the timeframe; treat missing systems as
+        # having no correlations.
         correlated_systems =
-          correlation_matrix[system.system_id]
+          correlation_matrix
+          |> Map.get(system.system_id, %{})
           |> Enum.filter(fn {_sys_id, corr} -> corr > threshold end)
           |> Enum.map(fn {sys_id, _corr} -> sys_id end)
 

--- a/test/eve_dmv/killmails/killmail_raw_test.exs
+++ b/test/eve_dmv/killmails/killmail_raw_test.exs
@@ -302,10 +302,14 @@ defmodule EveDmv.Killmails.KillmailRawTest do
       recent_killmail = Ash.create!(KillmailRaw, recent_attrs, domain: EveDmv.Api)
       old_killmail = Ash.create!(KillmailRaw, old_attrs, domain: EveDmv.Api)
 
-      # Load with calculation
+      # Load with calculation - filter to just our two records since the table
+      # may contain many killmails and the default safety limit caps reads.
+      ids = [recent_killmail.killmail_id, old_killmail.killmail_id]
+
       killmails =
         KillmailRaw
         |> Ash.Query.new()
+        |> Ash.Query.filter(expr(killmail_id in ^ids))
         |> Ash.Query.load([:is_recent])
         |> Ash.read!(domain: EveDmv.Api)
 

--- a/test/eve_dmv/static_data/ship_attribute_importer_test.exs
+++ b/test/eve_dmv/static_data/ship_attribute_importer_test.exs
@@ -154,13 +154,14 @@ defmodule EveDmv.StaticData.ShipAttributeImporterTest do
 
     @tag :requires_sde
     test "frigate classification includes assault frigates" do
-      # Import an Assault Frigate (Wolf = 22456)
-      result = ShipAttributeImporter.import_ship_attributes(22_456)
+      # Import an Assault Frigate (Wolf = 11371). Note: 22456 is the Sabre
+      # (Interdictor), so the prior value made this test fail with "destroyer".
+      result = ShipAttributeImporter.import_ship_attributes(11_371)
 
       case result do
         :ok ->
           # Verify the ship was classified - may be "frigate" or "unknown" depending on SDE
-          case EveDmv.StaticData.ShipAttributes.get_by_type_id(22_456) do
+          case EveDmv.StaticData.ShipAttributes.get_by_type_id(11_371) do
             {:ok, attrs} ->
               # Size class should be a valid string
               assert is_binary(attrs.size_class)

--- a/test/eve_dmv/static_data/ship_attribute_importer_test.exs
+++ b/test/eve_dmv/static_data/ship_attribute_importer_test.exs
@@ -163,10 +163,8 @@ defmodule EveDmv.StaticData.ShipAttributeImporterTest do
           # Verify the ship was classified - may be "frigate" or "unknown" depending on SDE
           case EveDmv.StaticData.ShipAttributes.get_by_type_id(11_371) do
             {:ok, attrs} ->
-              # Size class should be a valid string
-              assert is_binary(attrs.size_class)
-              # If SDE is fully loaded, it should be frigate; otherwise unknown is acceptable
-              assert attrs.size_class in ["frigate", "unknown"]
+              # The Wolf is an Assault Frigate; require it to be classified as "frigate".
+              assert attrs.size_class == "frigate"
 
             {:error, :not_found} ->
               # Ship not found after import, acceptable in test environment


### PR DESCRIPTION
Closes #25.

## Summary
Fixes the 9 pre-existing test failures observed while running the baseline suite for #24. Full suite now: **2501 tests, 0 failures (13 excluded)**.

## Root causes & fixes

- **`ShipAttributeImporterTest` — assault frigate classified as "destroyer".** Type ID `22456` is actually the Sabre (Interdictor); the test was importing the wrong ship. Switched to `11371` (Wolf, Assault Frigate).
- **`KillmailRawTest.is_recent` — `BadMapError: nil`.** Test read all `KillmailRaw` rows and `Enum.find`'d its records; the table holds ~210k killmails and the default 1000-row safety limit was excluding the freshly-inserted ones. Filtered the read to the two created ids.
- **`MigrationComparisonTest` (5 corp StatsLoader cases) — kills/active_members returned 0.** `corporation_member_summary` is a materialized view that (a) refreshes on a schedule and (b) `HAVING count(*) >= 5` per character. Test fixtures never appear in it, so the SUM-of-NULL row was being formatted as zero stats. `compute_stats/2` now falls back to the direct participants query when the matview returns null aggregates for a corp.
- **`SystemAnalysis.ApiTest analyze_regional_correlations/2` (2 cases) — `Protocol.UndefinedError ... got: nil`.** `correlation_matrix[system.system_id]` was nil for systems without killmails in the timeframe, then piped into `Enum.filter`. Used `Map.get(matrix, id, %{})`.

## Test plan
- [x] Targeted tests pass: `mix test test/eve_dmv/static_data/ship_attribute_importer_test.exs test/eve_dmv/migration_comparison_test.exs test/eve_dmv/killmails/killmail_raw_test.exs test/eve_dmv/contexts/system_analysis/api_test.exs`
- [x] Full suite passes: `mix test` → 2501 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of corporation statistics calculation to handle all-nil query results.
  * Enhanced regional activity analysis to safely handle missing system correlation data.

* **Tests**
  * Updated ship-attribute test data to a current type for accurate size-class assertions.
  * Narrowed killmail test queries to load only relevant records for faster, more reliable validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->