### PR TITLE
fix: resolve mix credo --strict warnings

### DIFF
--- a/lib/eve_dmv/contexts/battle_analysis/domain/ship_performance_analyzer.ex
+++ b/lib/eve_dmv/contexts/battle_analysis/domain/ship_performance_analyzer.ex
@@ -83,11 +83,7 @@ defmodule EveDmv.Contexts.BattleAnalysis.Domain.ShipPerformanceAnalyzer do
              {:ok, final_analysis} <-
                maybe_generate_recommendations(comparative_analysis, include_recommendations) do
           # Filter by focus ship if specified
-          filtered_analysis =
-            case focus_ship do
-              nil -> final_analysis
-              ship_type_id -> filter_by_ship_type(final_analysis, ship_type_id)
-            end
+          filtered_analysis = maybe_filter_by_ship_type(final_analysis, focus_ship)
 
           end_time = System.monotonic_time(:millisecond)
           duration_ms = end_time - start_time
@@ -1888,6 +1884,11 @@ defmodule EveDmv.Contexts.BattleAnalysis.Domain.ShipPerformanceAnalyzer do
       true -> :low
     end
   end
+
+  defp maybe_filter_by_ship_type(analysis, nil), do: analysis
+
+  defp maybe_filter_by_ship_type(analysis, ship_type_id),
+    do: filter_by_ship_type(analysis, ship_type_id)
 
   defp filter_by_ship_type(analysis, ship_type_id) do
     filtered_performances =

--- a/test/eve_dmv/contexts/battle_analysis/domain/participant_role_analyzer_test.exs
+++ b/test/eve_dmv/contexts/battle_analysis/domain/participant_role_analyzer_test.exs
@@ -94,7 +94,7 @@ defmodule EveDmv.Contexts.BattleAnalysis.Domain.ParticipantRoleAnalyzerTest do
       analysis = ParticipantRoleAnalyzer.analyze_participant_roles(battle)
 
       # Should identify potential commanders
-      assert length(analysis.commanders) >= 0
+      assert is_list(analysis.commanders)
 
       # If commanders identified, should have command indicators
       if analysis.commanders != [] do
@@ -161,7 +161,7 @@ defmodule EveDmv.Contexts.BattleAnalysis.Domain.ParticipantRoleAnalyzerTest do
       analysis = ParticipantRoleAnalyzer.analyze_participant_role(participant, killmails)
 
       # Should identify some characteristics based on the activity
-      assert length(analysis.characteristics) >= 0
+      assert is_list(analysis.characteristics)
     end
 
     test "handles participants with no activity" do

--- a/test/eve_dmv/contexts/battle_analysis/domain/tactical_pattern_detector_test.exs
+++ b/test/eve_dmv/contexts/battle_analysis/domain/tactical_pattern_detector_test.exs
@@ -239,7 +239,7 @@ defmodule EveDmv.Contexts.BattleAnalysis.Domain.TacticalPatternDetectorTest do
       analysis = TacticalPatternDetector.analyze_coordination(killmails)
 
       # Should identify breakdown periods
-      assert length(analysis.coordination_breakdown) >= 0
+      assert is_list(analysis.coordination_breakdown)
     end
   end
 


### PR DESCRIPTION
## Summary
- Reduce nesting depth in `ShipPerformanceAnalyzer.analyze_battle_performance/2` by extracting `maybe_filter_by_ship_type/2` helper (was depth 4, now 3)
- Replace `length(list) >= 0` (always-true, expensive) with `is_list/1` assertions in 3 test sites

## Test plan
- [x] `mix credo --strict` reports no issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal ship analysis logic for improved maintainability.

* **Tests**
  * Enhanced test validation assertions across battle analysis modules for greater accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->