### PR TITLE
fix(auth): replace retired ESI /verify/ endpoint with JWT-based identity

### DIFF
--- a/lib/eve_dmv/platform/auth/eve_sso_jwks.ex
+++ b/lib/eve_dmv/platform/auth/eve_sso_jwks.ex
@@ -22,26 +22,56 @@ defmodule EveDmv.Auth.EveSsoJwks do
 
   @doc """
   Returns the current JWKS key list, fetching and caching it if needed.
+
+  On a refresh path (`refresh?: true` or expired cache), if the upstream
+  fetch fails but a previously cached keyset exists, the stale keys are
+  returned rather than propagating the error. Cold-start failures still
+  surface as `{:error, _}` so misconfiguration is loud.
+
+  ## Options
+
+    * `:refresh?` (boolean) - bypass the TTL check
+    * `:http_request_fun` (test-only) - 0-arity fun returning the
+      result of `Assent.Strategy.http_request/5`
   """
   @spec get_keys(keyword()) :: {:ok, [map()]} | {:error, term()}
   def get_keys(opts \\ []) do
     refresh? = Keyword.get(opts, :refresh?, false)
 
     case :persistent_term.get(@cache_key, :miss) do
-      {expires_at, keys} when not refresh? ->
-        if System.monotonic_time(:millisecond) < expires_at do
-          {:ok, keys}
-        else
-          fetch_and_cache()
+      {expires_at, keys} ->
+        cond do
+          refresh? -> fetch_or_fallback(keys, opts)
+          System.monotonic_time(:millisecond) < expires_at -> {:ok, keys}
+          true -> fetch_or_fallback(keys, opts)
         end
 
-      _ ->
-        fetch_and_cache()
+      :miss ->
+        fetch_and_cache(opts)
     end
   end
 
-  defp fetch_and_cache do
-    case Assent.Strategy.http_request(:get, @jwks_url, nil, [], []) do
+  defp fetch_or_fallback(stale_keys, opts) do
+    case fetch_and_cache(opts) do
+      {:ok, _} = ok ->
+        ok
+
+      {:error, reason} ->
+        Logger.warning(
+          "EVE SSO JWKS refresh failed; falling back to previously cached keys: #{inspect(reason)}"
+        )
+
+        {:ok, stale_keys}
+    end
+  end
+
+  defp fetch_and_cache(opts) do
+    request_fun =
+      Keyword.get(opts, :http_request_fun, fn ->
+        Assent.Strategy.http_request(:get, @jwks_url, nil, [], [])
+      end)
+
+    case request_fun.() do
       {:ok, %HTTPResponse{status: 200, body: %{"keys" => keys}}} when is_list(keys) ->
         expires_at = System.monotonic_time(:millisecond) + @cache_ttl_ms
         :persistent_term.put(@cache_key, {expires_at, keys})

--- a/lib/eve_dmv/platform/auth/eve_sso_jwks.ex
+++ b/lib/eve_dmv/platform/auth/eve_sso_jwks.ex
@@ -1,0 +1,63 @@
+defmodule EveDmv.Auth.EveSsoJwks do
+  @moduledoc """
+  Fetches and caches the EVE SSO JSON Web Key Set used to verify v2
+  access tokens.
+
+  CCP retired the legacy `https://esi.evetech.net/verify/` endpoint, so
+  character identification now comes from validating the JWT access token
+  against the public keys published at `https://login.eveonline.com/oauth/jwks`.
+
+  Keys are cached in `:persistent_term` for one hour. Callers can pass
+  `refresh?: true` to bypass the cache (used after a `kid` lookup miss so
+  key rotations recover automatically).
+  """
+
+  alias Assent.HTTPAdapter.HTTPResponse
+
+  require Logger
+
+  @jwks_url "https://login.eveonline.com/oauth/jwks"
+  @cache_key {__MODULE__, :jwks_cache}
+  @cache_ttl_ms :timer.hours(1)
+
+  @doc """
+  Returns the current JWKS key list, fetching and caching it if needed.
+  """
+  @spec get_keys(keyword()) :: {:ok, [map()]} | {:error, term()}
+  def get_keys(opts \\ []) do
+    refresh? = Keyword.get(opts, :refresh?, false)
+
+    case :persistent_term.get(@cache_key, :miss) do
+      {expires_at, keys} when not refresh? ->
+        if System.monotonic_time(:millisecond) < expires_at do
+          {:ok, keys}
+        else
+          fetch_and_cache()
+        end
+
+      _ ->
+        fetch_and_cache()
+    end
+  end
+
+  defp fetch_and_cache do
+    case Assent.Strategy.http_request(:get, @jwks_url, nil, [], []) do
+      {:ok, %HTTPResponse{status: 200, body: %{"keys" => keys}}} when is_list(keys) ->
+        expires_at = System.monotonic_time(:millisecond) + @cache_ttl_ms
+        :persistent_term.put(@cache_key, {expires_at, keys})
+        {:ok, keys}
+
+      {:ok, %HTTPResponse{status: status, body: body}} ->
+        Logger.error("EVE SSO JWKS fetch returned #{status}: #{inspect(body)}")
+        {:error, "Unexpected JWKS response (status #{status})"}
+
+      {:error, reason} ->
+        Logger.error("EVE SSO JWKS fetch failed: #{inspect(reason)}")
+        {:error, reason}
+    end
+  end
+
+  @doc false
+  # Test-only: drop the cached value so the next fetch hits the network.
+  def reset_cache, do: :persistent_term.erase(@cache_key)
+end

--- a/lib/eve_dmv/platform/auth/eve_sso_strategy.ex
+++ b/lib/eve_dmv/platform/auth/eve_sso_strategy.ex
@@ -23,6 +23,7 @@ defmodule EveDmv.Auth.EveSsoStrategy do
   @behaviour Assent.Strategy
 
   alias Assent.Strategy.OAuth2
+  alias EveDmv.Telemetry.OtelSpans
 
   @expected_issuers ["login.eveonline.com", "https://login.eveonline.com"]
   @expected_audience "EVE Online"
@@ -43,11 +44,16 @@ defmodule EveDmv.Auth.EveSsoStrategy do
   @spec fetch_user(Keyword.t(), map()) :: {:ok, map()} | {:error, term()}
   def fetch_user(config, %{"access_token" => access_token}) when is_binary(access_token) do
     jwks_module = Keyword.get(config, :jwks_module, EveDmv.Auth.EveSsoJwks)
+    span = OtelSpans.start_task_span("eve_sso.fetch_user", %{})
 
-    with {:ok, keys} <- jwks_module.get_keys(),
-         {:ok, claims} <- verify_jwt(access_token, keys, jwks_module, config) do
-      build_user_info(claims)
+    result = do_fetch_user(access_token, config, jwks_module, span)
+
+    case result do
+      {:ok, _} -> OtelSpans.end_task_span(span, %{})
+      {:error, reason} -> OtelSpans.end_task_span_with_error(span, reason, %{})
     end
+
+    result
   end
 
   def fetch_user(_config, token) do
@@ -56,13 +62,30 @@ defmodule EveDmv.Auth.EveSsoStrategy do
 
   # ---- internal -----------------------------------------------------------
 
-  defp verify_jwt(token, keys, jwks_module, config) do
-    with {:ok, header} <- peek_header(token),
-         {:ok, key} <- find_key(header, keys, jwks_module),
-         {:ok, jwt} <- Assent.Strategy.verify_jwt(token, key, config),
-         :ok <- assert_signature_verified(jwt),
-         :ok <- validate_claims(jwt.claims) do
-      {:ok, jwt.claims}
+  defp do_fetch_user(access_token, config, jwks_module, span) do
+    with {:ok, header} <- peek_header(access_token),
+         _ <- OtelSpans.add_span_attributes(span, %{"token.kid" => Map.get(header, "kid")}),
+         {:ok, keys} <- jwks_module.get_keys(),
+         {:ok, key} <- find_key(header, keys, jwks_module, span),
+         {:ok, jwt} <- Assent.Strategy.verify_jwt(access_token, key, config),
+         :ok <- assert_signature_verified(jwt, span),
+         :ok <- validate_claims(jwt.claims, span),
+         {:ok, user_info} <- build_user_info(jwt.claims) do
+      OtelSpans.add_span_attributes(span, %{
+        "eve.character_id" => user_info["CharacterID"],
+        "token.iss" => Map.get(jwt.claims, "iss"),
+        "token.aud" => inspect(Map.get(jwt.claims, "aud")),
+        "token.exp" => Map.get(jwt.claims, "exp")
+      })
+
+      {:ok, user_info}
+    else
+      {:error, reason} = err ->
+        OtelSpans.add_span_event(span, "eve_sso.fetch_user.error", %{
+          "error.message" => to_string(reason)
+        })
+
+        err
     end
   end
 
@@ -77,15 +100,21 @@ defmodule EveDmv.Auth.EveSsoStrategy do
     end
   end
 
-  defp find_key(%{"kid" => kid}, keys, jwks_module) do
+  defp find_key(%{"kid" => kid}, keys, jwks_module, span) do
     case Enum.find(keys, &(Map.get(&1, "kid") == kid)) do
       nil ->
+        OtelSpans.add_span_event(span, "eve_sso.jwks.refresh", %{"token.kid" => kid})
         # Possible key rotation: refresh once before giving up.
         case jwks_module.get_keys(refresh?: true) do
           {:ok, refreshed} ->
             case Enum.find(refreshed, &(Map.get(&1, "kid") == kid)) do
-              nil -> {:error, "No EVE SSO JWKS key matches kid=#{inspect(kid)}"}
-              key -> {:ok, key}
+              nil ->
+                OtelSpans.add_span_event(span, "eve_sso.jwks.refresh.miss", %{"token.kid" => kid})
+                {:error, "No EVE SSO JWKS key matches kid=#{inspect(kid)}"}
+
+              key ->
+                OtelSpans.add_span_event(span, "eve_sso.jwks.refresh.hit", %{"token.kid" => kid})
+                {:ok, key}
             end
 
           {:error, _} = err ->
@@ -97,17 +126,31 @@ defmodule EveDmv.Auth.EveSsoStrategy do
     end
   end
 
-  defp find_key(_header, _keys, _jwks_module),
+  defp find_key(_header, _keys, _jwks_module, _span),
     do: {:error, "EVE SSO access token header missing kid"}
 
-  defp assert_signature_verified(%{verified?: true}), do: :ok
-  defp assert_signature_verified(_), do: {:error, "Invalid EVE SSO access token signature"}
+  defp assert_signature_verified(%{verified?: true}, _span), do: :ok
 
-  defp validate_claims(claims) do
+  defp assert_signature_verified(_, span) do
+    OtelSpans.add_span_event(span, "eve_sso.signature.invalid", %{})
+    {:error, "Invalid EVE SSO access token signature"}
+  end
+
+  defp validate_claims(claims, span) do
     with :ok <- validate_issuer(claims),
          :ok <- validate_audience(claims),
          :ok <- validate_expiry(claims) do
       :ok
+    else
+      {:error, message} = err ->
+        OtelSpans.add_span_event(span, "eve_sso.claims.invalid", %{
+          "error.message" => message,
+          "token.iss" => inspect(Map.get(claims, "iss")),
+          "token.aud" => inspect(Map.get(claims, "aud")),
+          "token.exp" => inspect(Map.get(claims, "exp"))
+        })
+
+        err
     end
   end
 

--- a/lib/eve_dmv/platform/auth/eve_sso_strategy.ex
+++ b/lib/eve_dmv/platform/auth/eve_sso_strategy.ex
@@ -1,0 +1,181 @@
+defmodule EveDmv.Auth.EveSsoStrategy do
+  @moduledoc """
+  Custom Assent strategy for EVE Online SSO v2.
+
+  Behaves exactly like `Assent.Strategy.OAuth2` for the authorize and
+  token-exchange phases, but resolves character identity by **decoding
+  the access token JWT** instead of calling the legacy
+  `https://esi.evetech.net/verify/` endpoint, which CCP retired.
+
+  The JWT is verified against CCP's public JWKS at
+  `https://login.eveonline.com/oauth/jwks`. The resulting user map is
+  shaped to match what the legacy `/verify/` endpoint returned
+  (`"CharacterID"`, `"CharacterName"`, `"Scopes"`, `"CharacterOwnerHash"`,
+  `"ExpiresOn"`) so downstream code in `EveDmv.Users.User` does not need
+  to change.
+
+  ## Options
+
+    - `:jwks_module` (test override) — module used to fetch the JWKS.
+      Defaults to `EveDmv.Auth.EveSsoJwks`.
+  """
+
+  @behaviour Assent.Strategy
+
+  alias Assent.Strategy.OAuth2
+
+  @expected_issuers ["login.eveonline.com", "https://login.eveonline.com"]
+  @expected_audience "EVE Online"
+
+  @impl Assent.Strategy
+  def authorize_url(config), do: OAuth2.authorize_url(config)
+
+  @impl Assent.Strategy
+  def callback(config, params), do: OAuth2.callback(config, params, __MODULE__)
+
+  @doc """
+  Resolves the EVE character from the access token JWT instead of calling
+  CCP's retired `/verify/` endpoint.
+
+  Invoked by `Assent.Strategy.OAuth2.callback/3` after a successful token
+  exchange.
+  """
+  @spec fetch_user(Keyword.t(), map()) :: {:ok, map()} | {:error, term()}
+  def fetch_user(config, %{"access_token" => access_token}) when is_binary(access_token) do
+    jwks_module = Keyword.get(config, :jwks_module, EveDmv.Auth.EveSsoJwks)
+
+    with {:ok, keys} <- jwks_module.get_keys(),
+         {:ok, claims} <- verify_jwt(access_token, keys, jwks_module, config) do
+      build_user_info(claims)
+    end
+  end
+
+  def fetch_user(_config, token) do
+    {:error, "EVE SSO callback returned no access_token: #{inspect(Map.keys(token))}"}
+  end
+
+  # ---- internal -----------------------------------------------------------
+
+  defp verify_jwt(token, keys, jwks_module, config) do
+    with {:ok, header} <- peek_header(token),
+         {:ok, key} <- find_key(header, keys, jwks_module),
+         {:ok, jwt} <- Assent.Strategy.verify_jwt(token, key, config),
+         :ok <- assert_signature_verified(jwt),
+         :ok <- validate_claims(jwt.claims) do
+      {:ok, jwt.claims}
+    end
+  end
+
+  # Decode the JWT header without verifying so we can look up the right key.
+  defp peek_header(token) do
+    with [encoded_header, _, _] <- String.split(token, "."),
+         {:ok, json} <- Base.url_decode64(encoded_header, padding: false),
+         {:ok, header} <- Jason.decode(json) do
+      {:ok, header}
+    else
+      _ -> {:error, "Invalid JWT format in EVE SSO access token"}
+    end
+  end
+
+  defp find_key(%{"kid" => kid}, keys, jwks_module) do
+    case Enum.find(keys, &(Map.get(&1, "kid") == kid)) do
+      nil ->
+        # Possible key rotation: refresh once before giving up.
+        case jwks_module.get_keys(refresh?: true) do
+          {:ok, refreshed} ->
+            case Enum.find(refreshed, &(Map.get(&1, "kid") == kid)) do
+              nil -> {:error, "No EVE SSO JWKS key matches kid=#{inspect(kid)}"}
+              key -> {:ok, key}
+            end
+
+          {:error, _} = err ->
+            err
+        end
+
+      key ->
+        {:ok, key}
+    end
+  end
+
+  defp find_key(_header, _keys, _jwks_module),
+    do: {:error, "EVE SSO access token header missing kid"}
+
+  defp assert_signature_verified(%{verified?: true}), do: :ok
+  defp assert_signature_verified(_), do: {:error, "Invalid EVE SSO access token signature"}
+
+  defp validate_claims(claims) do
+    with :ok <- validate_issuer(claims),
+         :ok <- validate_audience(claims),
+         :ok <- validate_expiry(claims) do
+      :ok
+    end
+  end
+
+  defp validate_issuer(%{"iss" => iss}) when is_binary(iss) do
+    if iss in @expected_issuers do
+      :ok
+    else
+      {:error, "EVE SSO token issuer #{inspect(iss)} not recognised"}
+    end
+  end
+
+  defp validate_issuer(_), do: {:error, "EVE SSO token missing iss claim"}
+
+  # CCP's tokens may set `aud` as a string or a list containing the
+  # client_id alongside the literal "EVE Online" audience.
+  defp validate_audience(%{"aud" => aud}) do
+    audiences = List.wrap(aud)
+
+    if @expected_audience in audiences do
+      :ok
+    else
+      {:error, "EVE SSO token audience #{inspect(aud)} does not include \"EVE Online\""}
+    end
+  end
+
+  defp validate_audience(_), do: {:error, "EVE SSO token missing aud claim"}
+
+  defp validate_expiry(%{"exp" => exp}) when is_integer(exp) do
+    if exp > System.system_time(:second) do
+      :ok
+    else
+      {:error, "EVE SSO access token has expired"}
+    end
+  end
+
+  defp validate_expiry(_), do: {:error, "EVE SSO token missing exp claim"}
+
+  # The `sub` claim is shaped like `"CHARACTER:EVE:91234567"`.
+  defp build_user_info(%{"sub" => sub} = claims) when is_binary(sub) do
+    case parse_character_id(sub) do
+      {:ok, character_id} ->
+        {:ok,
+         %{
+           "CharacterID" => character_id,
+           "CharacterName" => Map.get(claims, "name"),
+           "Scopes" => normalize_scopes(Map.get(claims, "scp")),
+           "CharacterOwnerHash" => Map.get(claims, "owner"),
+           "ExpiresOn" => Map.get(claims, "exp")
+         }}
+
+      :error ->
+        {:error, "Unrecognised EVE SSO sub claim: #{inspect(sub)}"}
+    end
+  end
+
+  defp build_user_info(_), do: {:error, "EVE SSO token missing sub claim"}
+
+  defp parse_character_id("CHARACTER:EVE:" <> id), do: parse_integer(id)
+  defp parse_character_id(_), do: :error
+
+  defp parse_integer(str) do
+    case Integer.parse(str) do
+      {int, ""} -> {:ok, int}
+      _ -> :error
+    end
+  end
+
+  defp normalize_scopes(nil), do: ""
+  defp normalize_scopes(scopes) when is_binary(scopes), do: scopes
+  defp normalize_scopes(scopes) when is_list(scopes), do: Enum.join(scopes, " ")
+end

--- a/lib/eve_dmv/platform/auth/eve_sso_strategy_extension.ex
+++ b/lib/eve_dmv/platform/auth/eve_sso_strategy_extension.ex
@@ -1,0 +1,59 @@
+defmodule EveDmv.Auth.EveSsoStrategyExtension do
+  @moduledoc """
+  Spark DSL extension that swaps the `:eve_sso` OAuth2 strategy's
+  `:assent_strategy` to `EveDmv.Auth.EveSsoStrategy` after
+  `AshAuthentication`'s own transformer has set the default
+  (`Assent.Strategy.OAuth2`).
+
+  This is the integration point that lets us replace the retired
+  `https://esi.evetech.net/verify/` `user_url` flow with a JWT-based
+  identity check, without forking AshAuthentication.
+  """
+
+  use Spark.Dsl.Extension, transformers: [EveDmv.Auth.EveSsoStrategyExtension.Transformer]
+
+  defmodule Transformer do
+    @moduledoc false
+    use Spark.Dsl.Transformer
+
+    alias Spark.Dsl.Transformer
+
+    @strategy_name :eve_sso
+    @custom_strategy EveDmv.Auth.EveSsoStrategy
+
+    @doc false
+    @impl Spark.Dsl.Transformer
+    def after?(AshAuthentication.Strategy.OAuth2.Transformer), do: true
+    def after?(_), do: false
+
+    @doc false
+    @impl Spark.Dsl.Transformer
+    def before?(_), do: false
+
+    @doc false
+    @impl Spark.Dsl.Transformer
+    def transform(dsl_state) do
+      strategies = Transformer.get_entities(dsl_state, [:authentication, :strategies])
+
+      case Enum.find(strategies, fn strategy ->
+             Map.get(strategy, :name) == @strategy_name
+           end) do
+        nil ->
+          {:ok, dsl_state}
+
+        strategy ->
+          updated = %{strategy | assent_strategy: @custom_strategy}
+
+          dsl_state =
+            Transformer.replace_entity(
+              dsl_state,
+              [:authentication, :strategies],
+              updated,
+              &(Map.get(&1, :name) == @strategy_name)
+            )
+
+          {:ok, dsl_state}
+      end
+    end
+  end
+end

--- a/lib/eve_dmv/platform/auth/user.ex
+++ b/lib/eve_dmv/platform/auth/user.ex
@@ -10,7 +10,7 @@ defmodule EveDmv.Users.User do
     otp_app: :eve_dmv,
     domain: EveDmv.Api,
     data_layer: AshPostgres.DataLayer,
-    extensions: [AshAuthentication],
+    extensions: [AshAuthentication, EveDmv.Auth.EveSsoStrategyExtension],
     authorizers: [Ash.Policy.Authorizer]
 
   alias Ash.Changeset
@@ -23,12 +23,23 @@ defmodule EveDmv.Users.User do
     # EVE SSO OAuth2 authentication strategy
     strategies do
       oauth2 :eve_sso do
+        # EVE SSO v2 embeds character info in the access-token JWT.
+        # CCP retired the legacy `https://esi.evetech.net/verify/`
+        # endpoint, so the `EveDmv.Auth.EveSsoStrategyExtension` swaps
+        # this strategy's Assent module to `EveDmv.Auth.EveSsoStrategy`,
+        # which decodes the JWT against CCP's published JWKS instead of
+        # calling `user_url`.
+        #
+        # `user_url` is still required by the AshAuthentication DSL
+        # schema but is never fetched. We point it at the JWKS URL as
+        # a non-404 placeholder; if the override is ever removed the
+        # error surface will be obvious.
         client_id(&get_eve_sso_config/2)
         client_secret(&get_eve_sso_config/2)
         base_url("https://login.eveonline.com")
         authorize_url("/v2/oauth/authorize")
         token_url("/v2/oauth/token")
-        user_url("https://esi.evetech.net/verify/")
+        user_url("https://login.eveonline.com/oauth/jwks")
         redirect_uri(&get_eve_sso_config/2)
         authorization_params(scope: "publicData")
         auth_method(:client_secret_basic)

--- a/lib/eve_dmv/platform/auth/user.ex
+++ b/lib/eve_dmv/platform/auth/user.ex
@@ -31,15 +31,16 @@ defmodule EveDmv.Users.User do
         # calling `user_url`.
         #
         # `user_url` is still required by the AshAuthentication DSL
-        # schema but is never fetched. We point it at the JWKS URL as
-        # a non-404 placeholder; if the override is ever removed the
-        # error surface will be obvious.
+        # schema but is never fetched. We point it at a deliberately
+        # invalid placeholder so any future regression that drops the
+        # extension surfaces immediately as a DNS failure rather than
+        # silently fetching whatever happens to be at a real URL.
         client_id(&get_eve_sso_config/2)
         client_secret(&get_eve_sso_config/2)
         base_url("https://login.eveonline.com")
         authorize_url("/v2/oauth/authorize")
         token_url("/v2/oauth/token")
-        user_url("https://login.eveonline.com/oauth/jwks")
+        user_url("https://invalid.eve-sso.placeholder.eve-dmv.local/")
         redirect_uri(&get_eve_sso_config/2)
         authorization_params(scope: "publicData")
         auth_method(:client_secret_basic)

--- a/test/eve_dmv/platform/auth/eve_sso_jwks_test.exs
+++ b/test/eve_dmv/platform/auth/eve_sso_jwks_test.exs
@@ -83,7 +83,13 @@ defmodule EveDmv.Auth.EveSsoJwksTest do
     {:ok, agent} = Agent.start_link(fn -> {0, raw_responses} end)
 
     fun = fn ->
-      Agent.get_and_update(agent, fn {n, [head | rest]} -> {head, {n + 1, rest}} end)
+      Agent.get_and_update(agent, fn
+        {n, [head | rest]} ->
+          {head, {n + 1, rest}}
+
+        {n, []} ->
+          raise "EveSsoJwksTest stub exhausted after #{n} call(s); add more responses"
+      end)
     end
 
     calls = fn -> Agent.get(agent, fn {n, _} -> n end) end

--- a/test/eve_dmv/platform/auth/eve_sso_jwks_test.exs
+++ b/test/eve_dmv/platform/auth/eve_sso_jwks_test.exs
@@ -1,0 +1,97 @@
+defmodule EveDmv.Auth.EveSsoJwksTest do
+  @moduledoc """
+  Tests for the EVE SSO JWKS cache. Covers cold-start, TTL hits,
+  refresh-driven re-fetch, and the stale-fallback path that protects
+  logins from transient JWKS upstream failures.
+
+  These tests touch `:persistent_term`, which is global state shared
+  across the whole VM. The suite is therefore `async: false` and
+  resets the cache around each case.
+  """
+
+  use ExUnit.Case, async: false
+
+  alias Assent.HTTPAdapter.HTTPResponse
+  alias EveDmv.Auth.EveSsoJwks
+
+  setup do
+    EveSsoJwks.reset_cache()
+    on_exit(&EveSsoJwks.reset_cache/0)
+    :ok
+  end
+
+  describe "get_keys/1" do
+    test "fetches and caches on cold start" do
+      keys = [%{"kid" => "k1"}]
+      {fun, calls} = stub([{:ok, keys}, {:ok, keys}])
+
+      assert {:ok, ^keys} = EveSsoJwks.get_keys(http_request_fun: fun)
+      assert calls.() == 1
+
+      # Second call hits the cache, no extra fetch
+      assert {:ok, ^keys} = EveSsoJwks.get_keys(http_request_fun: fun)
+      assert calls.() == 1
+    end
+
+    test "refresh? bypasses TTL and re-fetches" do
+      first = [%{"kid" => "k1"}]
+      second = [%{"kid" => "k2"}]
+      {fun, calls} = stub([{:ok, first}, {:ok, second}])
+
+      assert {:ok, ^first} = EveSsoJwks.get_keys(http_request_fun: fun)
+      assert {:ok, ^second} = EveSsoJwks.get_keys(refresh?: true, http_request_fun: fun)
+      assert calls.() == 2
+    end
+
+    test "falls back to stale cache when refresh fails" do
+      first = [%{"kid" => "k1"}]
+      {fun, calls} = stub([{:ok, first}, {:error, :timeout}])
+
+      assert {:ok, ^first} = EveSsoJwks.get_keys(http_request_fun: fun)
+
+      # Refresh fails upstream, but we still get the previously cached keys.
+      assert {:ok, ^first} = EveSsoJwks.get_keys(refresh?: true, http_request_fun: fun)
+      assert calls.() == 2
+    end
+
+    test "cold-start fetch failure surfaces as an error" do
+      {fun, _calls} = stub([{:error, :nxdomain}])
+
+      assert {:error, :nxdomain} = EveSsoJwks.get_keys(http_request_fun: fun)
+    end
+
+    test "non-200 cold-start response surfaces as an error" do
+      raw = {:ok, %HTTPResponse{status: 500, body: "server explosion"}}
+      {fun, _calls} = stub_raw([raw])
+
+      assert {:error, message} = EveSsoJwks.get_keys(http_request_fun: fun)
+      assert message =~ "status 500"
+    end
+  end
+
+  # ---- helpers ------------------------------------------------------------
+
+  # `responses` is a list of `{:ok, [keys]}` or `{:error, reason}` tuples.
+  # The returned function pops the next response on each call and the
+  # `calls` callback returns how many times it has been invoked.
+  defp stub(responses) do
+    raw = Enum.map(responses, &to_http_response/1)
+    stub_raw(raw)
+  end
+
+  defp stub_raw(raw_responses) do
+    {:ok, agent} = Agent.start_link(fn -> {0, raw_responses} end)
+
+    fun = fn ->
+      Agent.get_and_update(agent, fn {n, [head | rest]} -> {head, {n + 1, rest}} end)
+    end
+
+    calls = fn -> Agent.get(agent, fn {n, _} -> n end) end
+    {fun, calls}
+  end
+
+  defp to_http_response({:ok, keys}),
+    do: {:ok, %HTTPResponse{status: 200, body: %{"keys" => keys}}}
+
+  defp to_http_response({:error, _} = err), do: err
+end

--- a/test/eve_dmv/platform/auth/eve_sso_strategy_extension_test.exs
+++ b/test/eve_dmv/platform/auth/eve_sso_strategy_extension_test.exs
@@ -1,0 +1,30 @@
+defmodule EveDmv.Auth.EveSsoStrategyExtensionTest do
+  @moduledoc """
+  Regression test: the `EveSsoStrategyExtension` must replace the
+  `:eve_sso` strategy's default `Assent.Strategy.OAuth2` with our custom
+  JWT-based `EveDmv.Auth.EveSsoStrategy`. If the extension is ever
+  removed (or the strategy's transformer ordering changes), this test
+  fails fast instead of silently bringing back the retired
+  `https://esi.evetech.net/verify/` HTTP call.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias AshAuthentication.Info
+  alias EveDmv.Auth.EveSsoStrategy
+
+  test "the :eve_sso strategy uses the custom JWT-based Assent strategy" do
+    assert {:ok, strategy} = Info.strategy(EveDmv.Users.User, :eve_sso)
+    assert strategy.assent_strategy == EveSsoStrategy
+  end
+
+  test "user_url is a deliberately invalid placeholder so regressions are loud" do
+    assert {:ok, strategy} = Info.strategy(EveDmv.Users.User, :eve_sso)
+    url = strategy.user_url
+    assert is_binary(url)
+    assert url =~ "invalid"
+    assert url =~ "placeholder"
+    refute url =~ "esi.evetech.net"
+    refute url =~ "login.eveonline.com"
+  end
+end

--- a/test/eve_dmv/platform/auth/eve_sso_strategy_test.exs
+++ b/test/eve_dmv/platform/auth/eve_sso_strategy_test.exs
@@ -18,6 +18,11 @@ defmodule EveDmv.Auth.EveSsoStrategyTest do
 
   alias EveDmv.Auth.EveSsoStrategy
 
+  @character_id 91_234_567
+  @character_name "Test Pilot"
+  @owner_hash "abcdefg1234567890"
+  @kid "test-kid-1"
+
   defmodule JwksStub do
     @moduledoc false
     # Test-only JWKS module. The keys (and a refreshed key list, if any)
@@ -47,11 +52,6 @@ defmodule EveDmv.Auth.EveSsoStrategyTest do
       {:ok, keys}
     end
   end
-
-  @character_id 91_234_567
-  @character_name "Test Pilot"
-  @owner_hash "abcdefg1234567890"
-  @kid "test-kid-1"
 
   setup do
     {private_jwk, public_jwk} = generate_jwk(@kid)

--- a/test/eve_dmv/platform/auth/eve_sso_strategy_test.exs
+++ b/test/eve_dmv/platform/auth/eve_sso_strategy_test.exs
@@ -1,0 +1,240 @@
+defmodule EveDmv.Auth.EveSsoStrategyTest do
+  @moduledoc """
+  Unit tests for `EveDmv.Auth.EveSsoStrategy`, which replaces the retired
+  `https://esi.evetech.net/verify/` endpoint with a JWT-based identity
+  check against CCP's published JWKS.
+
+  Tokens are signed with a locally generated RSA key, the matching
+  public JWK is served through a stub JWKS module, and we confirm the
+  strategy:
+
+    * returns the legacy `/verify/`-shaped user info on the happy path
+    * rejects missing/invalid signatures
+    * rejects unexpected issuer/audience/expiry/sub claims
+    * triggers a JWKS refresh when the `kid` is unknown
+  """
+
+  use ExUnit.Case, async: true
+
+  alias EveDmv.Auth.EveSsoStrategy
+
+  defmodule JwksStub do
+    @moduledoc false
+    # Test-only JWKS module. The keys (and a refreshed key list, if any)
+    # are stashed in a per-test Agent whose pid is read from the Logger
+    # metadata so we don't have to thread it through the strategy API.
+    use Agent
+
+    def start_link(initial: initial, refreshed: refreshed) do
+      Agent.start_link(fn -> %{initial: initial, refreshed: refreshed, calls: []} end)
+    end
+
+    def calls(agent), do: Agent.get(agent, & &1.calls)
+
+    def install(agent), do: Process.put(__MODULE__, agent)
+
+    def get_keys(opts \\ []) do
+      refresh? = Keyword.get(opts, :refresh?, false)
+      agent = Process.get(__MODULE__) || raise "JwksStub not installed for this test"
+
+      keys =
+        Agent.get_and_update(agent, fn state ->
+          new = %{state | calls: state.calls ++ [refresh?]}
+          keys = if refresh?, do: state.refreshed, else: state.initial
+          {keys, new}
+        end)
+
+      {:ok, keys}
+    end
+  end
+
+  @character_id 91_234_567
+  @character_name "Test Pilot"
+  @owner_hash "abcdefg1234567890"
+  @kid "test-kid-1"
+
+  setup do
+    {private_jwk, public_jwk} = generate_jwk(@kid)
+    {:ok, private_jwk: private_jwk, public_jwk: public_jwk}
+  end
+
+  describe "fetch_user/2 - happy path" do
+    test "returns legacy /verify/-shaped user info from a valid JWT", %{
+      private_jwk: private,
+      public_jwk: public
+    } do
+      install_jwks(initial: [public])
+      token = sign_token(private, base_claims())
+
+      assert {:ok, user_info} =
+               EveSsoStrategy.fetch_user(test_config(), %{"access_token" => token})
+
+      assert user_info["CharacterID"] == @character_id
+      assert user_info["CharacterName"] == @character_name
+      assert user_info["CharacterOwnerHash"] == @owner_hash
+      assert user_info["Scopes"] == "publicData esi-killmails.read_killmails.v1"
+      assert is_integer(user_info["ExpiresOn"])
+    end
+
+    test "accepts list-shaped audience containing \"EVE Online\"", %{
+      private_jwk: private,
+      public_jwk: public
+    } do
+      install_jwks(initial: [public])
+      token = sign_token(private, Map.put(base_claims(), "aud", ["EVE Online", "client-id"]))
+
+      assert {:ok, _} =
+               EveSsoStrategy.fetch_user(test_config(), %{"access_token" => token})
+    end
+
+    test "joins list-shaped scp claim into a space-separated string", %{
+      private_jwk: private,
+      public_jwk: public
+    } do
+      install_jwks(initial: [public])
+      claims = Map.put(base_claims(), "scp", ["publicData", "esi-killmails.read_killmails.v1"])
+      token = sign_token(private, claims)
+
+      assert {:ok, %{"Scopes" => "publicData esi-killmails.read_killmails.v1"}} =
+               EveSsoStrategy.fetch_user(test_config(), %{"access_token" => token})
+    end
+  end
+
+  describe "fetch_user/2 - validation failures" do
+    test "rejects token signed with a different key", %{public_jwk: public} do
+      install_jwks(initial: [public])
+      {other_private, _} = generate_jwk(@kid)
+      token = sign_token(other_private, base_claims())
+
+      assert {:error, message} =
+               EveSsoStrategy.fetch_user(test_config(), %{"access_token" => token})
+
+      assert message =~ "Invalid EVE SSO access token signature"
+    end
+
+    test "rejects token with unexpected issuer", %{private_jwk: private, public_jwk: public} do
+      install_jwks(initial: [public])
+      token = sign_token(private, Map.put(base_claims(), "iss", "https://evil.example.com"))
+
+      assert {:error, message} =
+               EveSsoStrategy.fetch_user(test_config(), %{"access_token" => token})
+
+      assert message =~ "issuer"
+    end
+
+    test "rejects token with audience missing \"EVE Online\"", %{
+      private_jwk: private,
+      public_jwk: public
+    } do
+      install_jwks(initial: [public])
+      token = sign_token(private, Map.put(base_claims(), "aud", ["other-client-id"]))
+
+      assert {:error, message} =
+               EveSsoStrategy.fetch_user(test_config(), %{"access_token" => token})
+
+      assert message =~ "audience"
+    end
+
+    test "rejects expired token", %{private_jwk: private, public_jwk: public} do
+      install_jwks(initial: [public])
+      claims = Map.put(base_claims(), "exp", System.system_time(:second) - 60)
+      token = sign_token(private, claims)
+
+      assert {:error, "EVE SSO access token has expired"} =
+               EveSsoStrategy.fetch_user(test_config(), %{"access_token" => token})
+    end
+
+    test "rejects token with unparseable sub claim", %{private_jwk: private, public_jwk: public} do
+      install_jwks(initial: [public])
+      token = sign_token(private, Map.put(base_claims(), "sub", "ALLIANCE:EVE:1234"))
+
+      assert {:error, message} =
+               EveSsoStrategy.fetch_user(test_config(), %{"access_token" => token})
+
+      assert message =~ "sub"
+    end
+
+    test "fails cleanly when the access_token field is missing" do
+      install_jwks(initial: [])
+
+      assert {:error, message} =
+               EveSsoStrategy.fetch_user(test_config(), %{"refresh_token" => "x"})
+
+      assert message =~ "no access_token"
+    end
+  end
+
+  describe "fetch_user/2 - JWKS refresh on unknown kid" do
+    test "refreshes JWKS once when initial key list misses the token's kid", %{
+      private_jwk: private,
+      public_jwk: public
+    } do
+      agent = install_jwks(initial: [], refreshed: [public])
+      token = sign_token(private, base_claims())
+
+      assert {:ok, _} =
+               EveSsoStrategy.fetch_user(test_config(), %{"access_token" => token})
+
+      assert JwksStub.calls(agent) == [false, true]
+    end
+
+    test "returns an error when the kid is missing even after refresh", %{
+      private_jwk: private
+    } do
+      install_jwks(initial: [], refreshed: [])
+      token = sign_token(private, base_claims())
+
+      assert {:error, message} =
+               EveSsoStrategy.fetch_user(test_config(), %{"access_token" => token})
+
+      assert message =~ "No EVE SSO JWKS key matches"
+    end
+  end
+
+  # ---- helpers ------------------------------------------------------------
+
+  defp install_jwks(opts) do
+    initial = Keyword.fetch!(opts, :initial)
+    refreshed = Keyword.get(opts, :refreshed, initial)
+    {:ok, agent} = JwksStub.start_link(initial: initial, refreshed: refreshed)
+    JwksStub.install(agent)
+    agent
+  end
+
+  defp test_config,
+    do: [
+      jwks_module: JwksStub,
+      json_library: Jason,
+      jwt_adapter: Assent.JWTAdapter.AssentJWT
+    ]
+
+  defp base_claims do
+    %{
+      "iss" => "login.eveonline.com",
+      "aud" => "EVE Online",
+      "sub" => "CHARACTER:EVE:#{@character_id}",
+      "name" => @character_name,
+      "owner" => @owner_hash,
+      "scp" => "publicData esi-killmails.read_killmails.v1",
+      "exp" => System.system_time(:second) + 1200,
+      "iat" => System.system_time(:second)
+    }
+  end
+
+  defp generate_jwk(kid) do
+    rsa = JOSE.JWK.generate_key({:rsa, 2048})
+    {_, public_map} = JOSE.JWK.to_public_map(rsa)
+    public = Map.merge(public_map, %{"kid" => kid, "alg" => "RS256", "use" => "sig"})
+    # Hand the private JWK back as a JOSE.JWK struct so we can sign with it directly.
+    {%{"jose_jwk" => rsa, "kid" => kid}, public}
+  end
+
+  defp sign_token(%{"jose_jwk" => rsa, "kid" => kid}, claims) do
+    {_, token} =
+      rsa
+      |> JOSE.JWT.sign(%{"alg" => "RS256", "kid" => kid, "typ" => "JWT"}, claims)
+      |> JOSE.JWS.compact()
+
+    token
+  end
+end


### PR DESCRIPTION
## Summary

Production logins are failing with the toast **\"Authentication failed: please try again\"**. The Phoenix logs show:

\`\`\`
AUTH FAILURE - activity: {:eve_sso, :callback}
reason: %Assent.InvalidResponseError{
  request_url: \"https://esi.evetech.net/verify/\",
  status: 404,
  body: \"404 page not found\"
}
\`\`\`

CCP retired the legacy v1 \`/verify/\` endpoint that the default \`Assent.Strategy.OAuth2\` was hitting after token exchange. EVE SSO **v2** (which we use) embeds character info directly in the access-token JWT, so no userinfo HTTP call is needed — we just have to verify the JWT against CCP's published JWKS.

## Changes

- **\`EveDmv.Auth.EveSsoJwks\`** — fetches and 1h-caches CCP's JWKS at \`https://login.eveonline.com/oauth/jwks\`. Refreshes on \`kid\` miss to handle key rotation.
- **\`EveDmv.Auth.EveSsoStrategy\`** — custom Assent strategy. Delegates authorize/token-exchange to \`Assent.Strategy.OAuth2\`; resolves the user by verifying the access-token JWT (signature, \`iss\`, \`aud=\"EVE Online\"\`, \`exp\`, \`sub\`). Returns the legacy \`/verify/\`-shaped map (\`CharacterID\`, \`CharacterName\`, \`Scopes\`, \`CharacterOwnerHash\`, \`ExpiresOn\`) so existing \`extract_eve_sso_data/2\` keeps working unchanged.
- **\`EveDmv.Auth.EveSsoStrategyExtension\`** — Spark DSL extension whose transformer runs after \`AshAuthentication.Strategy.OAuth2.Transformer\` and swaps \`:assent_strategy\` to our module. (\`:assent_strategy\` isn't user-facing in the AshAuth oauth2 DSL.)
- \`user.ex\` — adds the extension; \`user_url\` is required by the DSL schema but no longer fetched, so it's pointed at the JWKS URL as a non-404 placeholder.

## Test plan

- [x] \`mix test test/eve_dmv/platform/auth/eve_sso_strategy_test.exs\` — 11 tests, 0 failures (happy path, signature/issuer/audience/expiry/sub validation, JWKS refresh-on-unknown-kid)
- [x] \`mix test test/eve_dmv_web/controllers/auth_controller_test.exs\` — 14 tests + 1 property, 0 failures (no regressions)
- [x] \`mix compile --warnings-as-errors\` clean
- [x] \`mix format --check-formatted\` clean
- [x] \`mix credo --strict\` clean on changed files
- [ ] Smoke-test prod login end-to-end after deploy

## Out of scope

- The unrelated \`site-*.webmanifest\` 404 in browser console (cosmetic PWA file, doesn't affect auth).
- Token *refresh* — already works (refresh logs show \`POST .../v2/oauth/token -> 200\` for all 10 stored characters).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * EVE Online SSO now validates tokens using JWKS with automatic key rotation and short-lived caching (~1 hour) for more reliable authentication.
  * OAuth2 strategy switched to a JWT-based flow and integrated into the app’s authentication configuration.

* **Tests**
  * Comprehensive tests added for JWKS fetching/caching, key rotation/refresh, signature and claim validation, and strategy integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->